### PR TITLE
[WIP] Rewrite encoders using semiauto derivation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,6 +20,7 @@ val databaseDependencies = Seq(
 val apiDependencies = Seq(
   "io.circe" %% "circe-core" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion,
+  "io.circe" %% "circe-generic-extras" % circeVersion,
   "io.circe" %% "circe-parser" % circeVersion,
   "io.swagger" %% "swagger-scala-module" % "1.0.3",
   "com.github.swagger-akka-http" %% "swagger-akka-http" % "0.10.0",

--- a/src/main/scala/org/encryfoundation/explorer/db/models/Output.scala
+++ b/src/main/scala/org/encryfoundation/explorer/db/models/Output.scala
@@ -1,5 +1,6 @@
 package org.encryfoundation.explorer.db.models
 
+
 case class Output(id: String,
                   txId: String,
                   monetaryValue: Long,
@@ -10,14 +11,16 @@ case class Output(id: String,
 object Output {
 
   import io.circe.Encoder
-  import io.circe.syntax._
+  import io.circe.generic.extras._
 
-  implicit val jsonEncoder: Encoder[Output] = (o: Output) => Map(
-    "id" -> o.id.asJson,
-    "parentId" -> o.txId.asJson,
-    "value" -> o.monetaryValue.asJson,
-    "coinId" -> o.coinId.asJson,
-    "contractHash" -> o.contractHash.asJson,
-    "data" -> o.data.asJson
-  ).asJson
+  private implicit val config: Configuration = Configuration.default.copy(
+    transformMemberNames = {
+      case "monetaryValue" => "value"
+      case "txId" => "parentId"
+      case other => other
+    }
+  )
+
+  implicit val jsonEncoder: Encoder[Output] = semiauto.deriveEncoder
+
 }


### PR DESCRIPTION
This PR is proposal to rewrite json encoders using semiauto derivation from circe generic extras package, it uses shapeless under the hood. 

Pros:
- code looks cleaner

Cons: 
- runtime overhead because of shapeless
- if class member is renamed, compiler won't help you to keep name transformer in sync 

Only one for now as an example.